### PR TITLE
Fix incorrect config paths in action scripts

### DIFF
--- a/src/actions/get-DJs-details.php
+++ b/src/actions/get-DJs-details.php
@@ -1,5 +1,5 @@
 <?php
-include_once(__DIR__ . '/../config/config.php');
+include_once(__DIR__ . '/../../config/config.php');
 
 function obtenerConexion()
 {

--- a/src/actions/get-all-DJs.php
+++ b/src/actions/get-all-DJs.php
@@ -1,5 +1,5 @@
 <?php
-include_once(__DIR__ . '/../config/config.php');
+include_once(__DIR__ . '/../../config/config.php');
 
 // Habilitar reportes de errores para MySQLi
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);

--- a/src/actions/get-all-portfolios.php
+++ b/src/actions/get-all-portfolios.php
@@ -1,5 +1,5 @@
 <?php
-include_once(__DIR__ . '/../config/config.php');
+include_once(__DIR__ . '/../../config/config.php');
 
 function obtenerConexion()
 {

--- a/src/actions/get-artists.php
+++ b/src/actions/get-artists.php
@@ -1,5 +1,5 @@
 <?php
-include_once(__DIR__ . '/../config/config.php');
+include_once(__DIR__ . '/../../config/config.php');
 
 try {
     $dsn = "mysql:host=" . DB_HOST . ";dbname=" . DB_NAME . ";charset=utf8mb4";

--- a/src/actions/get-category.php
+++ b/src/actions/get-category.php
@@ -1,5 +1,5 @@
 <?php
-include_once(__DIR__ . '/../config/config.php');
+include_once(__DIR__ . '/../../config/config.php');
 
 function connectDatabase() {
     static $conn = null;

--- a/src/actions/get-portfolio-details.php
+++ b/src/actions/get-portfolio-details.php
@@ -1,5 +1,5 @@
 <?php
-include_once(__DIR__ . '/../config/config.php');
+include_once(__DIR__ . '/../../config/config.php');
 
 function getPortfolioDetails($id) {
     if (!isset($id) || !is_numeric($id) || $id <= 0) {

--- a/src/actions/portfolio-details-prueba.php
+++ b/src/actions/portfolio-details-prueba.php
@@ -1,5 +1,5 @@
 <?php
-include_once(__DIR__ . '/../config/config.php');
+include_once(__DIR__ . '/../../config/config.php');
 
 if (isset($_GET['id'])) {
     // Validar y sanitizar el parámetro 'id'

--- a/src/actions/register_visit.php
+++ b/src/actions/register_visit.php
@@ -1,5 +1,5 @@
 <?php
-include_once(__DIR__ . '/../config/config.php');
+include_once(__DIR__ . '/../../config/config.php');
 
 try {
     $options = [


### PR DESCRIPTION
## Summary
- Fix path to configuration file in action scripts to ensure database constants load correctly

## Testing
- `for f in src/actions/get-artists.php src/actions/get-category.php src/actions/portfolio-details-prueba.php src/actions/get-all-portfolios.php src/actions/register_visit.php src/actions/get-all-DJs.php src/actions/get-DJs-details.php src/actions/get-portfolio-details.php; do php -l $f; done`

------
https://chatgpt.com/codex/tasks/task_e_68957f6b96f8832cbd8baabdaf909823